### PR TITLE
feat: add digitalSTROM scene events support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,114 @@ This integration allows you to connect your digitalSTROM server (dSS) to Home As
 2. Enter your username and password of your dSS.
 3. If you are using a self-signed certificate on the dSS you need to [find out its SHA-256 fingerprint](https://github.com/Mat931/digitalstrom-homeassistant/blob/main/certificate_fingerprint.md). This fingerprint is used to verify the identity of the server.
 4. In the next step you can check if the correct areas got assigned to your digitalSTROM devices.
+
+## Using digitalSTROM scene events
+
+This integration exposes digitalSTROM scene changes as Home Assistant events.
+
+Whenever a scene is triggered in digitalSTROM (for example via a physical switch or automation), a corresponding event is fired on the Home Assistant event bus.
+
+Home Assistant is built around events — every action in the system produces an event, which can be used to trigger automations. :contentReference[oaicite:0]{index=0}
+
+### Event type
+
+```yaml
+digitalstrom_scene
+```
+
+### Event data
+
+```yaml
+scene: <scene id>
+zone: <zone id>
+group: <group id>
+```
+
+### Example event
+
+```yaml
+event_type: digitalstrom_scene
+data:
+  scene: 17
+  zone: 61667
+  group: 1
+origin: LOCAL
+```
+
+### How to inspect events
+
+1. Open **Developer Tools → Events** in Home Assistant  
+2. Enter:
+
+```yaml
+digitalstrom_scene
+```
+
+3. Click **Start listening**  
+4. Trigger a scene via digitalSTROM  
+5. Observe the incoming event  
+
+Home Assistant allows automations to be triggered directly from events and optionally filtered by their data. :contentReference[oaicite:1]{index=1}
+
+### Finding scene, zone and group IDs
+
+The IDs used in the event data are provided by digitalSTROM and may not match the names shown in the UI.
+
+To identify them:
+
+- Trigger a scene in digitalSTROM
+- Observe the event in Developer Tools
+- Note the values of `scene`, `zone`, and `group`
+
+### Example: Trigger automation on a specific scene
+
+```yaml
+alias: Example - react to a specific digitalSTROM scene
+triggers:
+  - trigger: event
+    event_type: digitalstrom_scene
+    event_data:
+      scene: 17
+      zone: 61667
+      group: 1
+actions:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.example
+mode: single
+```
+
+### Example: React differently depending on the scene
+
+```yaml
+alias: Example - scene-dependent behavior
+triggers:
+  - trigger: event
+    event_type: digitalstrom_scene
+    event_data:
+      zone: 61667
+      group: 1
+
+actions:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.scene | int == 17 }}"
+        sequence:
+          - action: switch.turn_on
+            target:
+              entity_id: switch.example
+    default:
+      - action: switch.turn_off
+        target:
+          entity_id: switch.example
+
+mode: single
+```
+
+### Notes
+
+- Events are emitted for every scene change in digitalSTROM
+- Use `scene`, `zone`, and `group` to filter events reliably
+- Multiple triggers can be combined in a single automation
+- This feature enables seamless integration of digitalSTROM inputs into Home Assistant automations

--- a/README_de.md
+++ b/README_de.md
@@ -24,3 +24,114 @@ Mit dieser Integration können Sie Ihren digitalSTROM-Server (dSS) mit Home Assi
 2. Geben Sie Nutzername und Passwort des digitalSTROM-Servers ein.
 3. Wenn Sie ein selbst-signiertes Zertifikat auf dem dSS nutzen müssen Sie dessen [SHA-256 Fingerabdruck herausfinden](https://github.com/Mat931/digitalstrom-homeassistant/blob/main/certificate_fingerprint_de.md). Dieser Fingerabdruck wird genutzt, um die Identität des Servers zu bestätigen.
 4. Im folgenden Schritt können Sie prüfen, ob Ihren digitalSTROM-Geräten die richtigen Zonen zugeordnet wurden.
+
+## Verwendung von digitalSTROM Szenen-Events
+
+Diese Integration stellt Szenenwechsel aus digitalSTROM als Home Assistant Events zur Verfügung.
+
+Immer wenn eine Szene in digitalSTROM ausgelöst wird (z. B. über einen physischen Taster oder eine Automation), wird ein entsprechendes Event im Home Assistant Event-Bus erzeugt.
+
+Events sind die Grundlage von Home Assistant: Immer wenn etwas passiert, wird ein Event erzeugt, das wiederum Automationen auslösen kann. :contentReference[oaicite:0]{index=0}
+
+### Event-Typ
+
+```yaml
+digitalstrom_scene
+```
+
+### Event-Daten
+
+```yaml
+scene: <Szenen-ID>
+zone: <Zonen-ID>
+group: <Gruppen-ID>
+```
+
+### Beispiel-Event
+
+```yaml
+event_type: digitalstrom_scene
+data:
+  scene: 17
+  zone: 61667
+  group: 1
+origin: LOCAL
+```
+
+### Events anzeigen (Debugging)
+
+1. Öffne **Entwicklerwerkzeuge → Ereignisse** in Home Assistant  
+2. Trage ein:
+
+```yaml
+digitalstrom_scene
+```
+
+3. Klicke auf **„Zuhören starten“**  
+4. Löse eine Szene über digitalSTROM aus  
+5. Beobachte das eingehende Event  
+
+### Szenen-, Zonen- und Gruppen-IDs herausfinden
+
+Die IDs stammen direkt aus digitalSTROM und entsprechen nicht zwingend den Anzeigenamen wie „Stimmung 1“ oder „Stimmung 2“.
+
+So findest du die richtigen Werte:
+
+- Szene in digitalSTROM auslösen  
+- Event in den Entwicklerwerkzeugen beobachten  
+- Werte für `scene`, `zone` und `group` notieren  
+
+### Beispiel: Automation für eine bestimmte Szene
+
+```yaml
+alias: Beispiel - Reagiere auf eine bestimmte digitalSTROM Szene
+triggers:
+  - trigger: event
+    event_type: digitalstrom_scene
+    event_data:
+      scene: 17
+      zone: 61667
+      group: 1
+
+actions:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.example
+
+mode: single
+```
+
+### Beispiel: Unterschiedliches Verhalten je nach Szene
+
+```yaml
+alias: Beispiel - Szenenabhängige Steuerung
+triggers:
+  - trigger: event
+    event_type: digitalstrom_scene
+    event_data:
+      zone: 61667
+      group: 1
+
+actions:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.scene | int == 17 }}"
+        sequence:
+          - action: switch.turn_on
+            target:
+              entity_id: switch.example
+    default:
+      - action: switch.turn_off
+        target:
+          entity_id: switch.example
+
+mode: single
+```
+
+### Hinweise
+
+- Für jede Szenenänderung in digitalSTROM wird ein Event erzeugt  
+- Verwende `scene`, `zone` und `group`, um Events zuverlässig zu filtern  
+- Mehrere Trigger können in einer Automation kombiniert werden  
+- Diese Funktion ermöglicht es, physische digitalSTROM Eingaben direkt in Home Assistant Automationen zu nutzen

--- a/custom_components/digitalstrom/__init__.py
+++ b/custom_components/digitalstrom/__init__.py
@@ -49,14 +49,10 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """
-    load configuration for digitalSTROM component
-    """
-    # not configured
+    """Load configuration for digitalSTROM component."""
     if DOMAIN not in config:
         return True
 
-    # already imported
     if hass.config_entries.async_entries(DOMAIN):
         return True
 
@@ -78,8 +74,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         system_dsuid = await client.get_system_dsuid()
-        if len(system_dsuid) < 8:  # 34
+        if len(system_dsuid) < 8:
             raise ConfigEntryError("Invalid system DSUID received")
+
         if system_dsuid != entry.unique_id:
             _LOGGER.warning(
                 f"Your system DSUID changed from {entry.unique_id} to {system_dsuid}"
@@ -98,13 +95,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
             else:
                 await migrate_system_dsuid(hass, entry, system_dsuid)
+
         apartment = DigitalstromApartment(client, system_dsuid)
+
         hass.data[DOMAIN].setdefault(entry.unique_id, dict())
         hass.data[DOMAIN][entry.unique_id]["client"] = client
         hass.data[DOMAIN][entry.unique_id]["apartment"] = apartment
+        hass.data[DOMAIN][entry.unique_id]["hass"] = hass
+
         await apartment.get_zones()
         await apartment.get_circuits()
         await apartment.get_devices()
+
+        # 🔥 NEW: Event callback registrieren
+        client.set_event_callback(
+            lambda event: handle_digitalstrom_event(hass, entry.unique_id, event)
+        )
+
     except (InvalidAuth, InvalidCertificate) as ex:
         raise ConfigEntryAuthFailed(ex) from ex
     except (CannotConnect, ServerError) as ex:
@@ -125,8 +132,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def stop_watchdog(event: Any = None) -> None:
         await async_unload_entry(hass, entry)
 
-    # If Home Assistant is already in a running state, start the watchdog
-    # immediately, else trigger it after Home Assistant has finished starting.
     if hass.state == CoreState.running:
         await start_watchdog()
     else:
@@ -139,6 +144,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def handle_digitalstrom_event(
+    hass: HomeAssistant, entry_id: str, event: dict
+) -> None:
+    """Handle incoming digitalSTROM events."""
+
+    if event.get("name") == "callScene":
+        props = event.get("properties", {})
+
+        try:
+            hass.bus.async_fire(
+                "digitalstrom_scene",
+                {
+                    "scene": int(props.get("sceneID", -1)),
+                    "zone": int(props.get("zoneID", -1)),
+                    "group": int(props.get("groupID", -1)),
+                },
+            )
+        except Exception as e:
+            _LOGGER.error("Failed to process digitalSTROM event: %s", e)
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
@@ -147,8 +173,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             is not None
         ):
             remove_watchdog()
+
         await hass.data[DOMAIN][entry.unique_id]["client"].stop_event_listener()
         hass.data[DOMAIN].pop(entry.unique_id)
+
     return unload_ok
 
 
@@ -163,23 +191,27 @@ async def migrate_system_dsuid(
     hass: HomeAssistant, config_entry: ConfigEntry, new_dsuid: str
 ) -> None:
     old_dsuid = config_entry.unique_id
+
     if old_dsuid is None or old_dsuid == new_dsuid or len(new_dsuid) < 8:
         return
 
     new_data = dict(config_entry.data)
     new_data[CONF_DSUID] = new_dsuid
+
     hass.config_entries.async_update_entry(
         config_entry, data=new_data, unique_id=new_dsuid
     )
 
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
+
     device_entries = dr.async_entries_for_config_entry(
         device_registry, config_entry_id=config_entry.entry_id
     )
     entity_entries = er.async_entries_for_config_entry(
         entity_registry, config_entry_id=config_entry.entry_id
     )
+
     for dev in device_entries:
         new_unique_id = None
         for identifier in dev.identifiers:
@@ -193,6 +225,7 @@ async def migrate_system_dsuid(
             device_registry.async_update_device(
                 dev.id, new_identifiers={(DOMAIN, new_unique_id)}
             )
+
     for ent in entity_entries:
         if old_dsuid in ent.unique_id:
             new_unique_id = ent.unique_id.replace(old_dsuid, new_dsuid)

--- a/custom_components/digitalstrom/api/client.py
+++ b/custom_components/digitalstrom/api/client.py
@@ -6,7 +6,7 @@ import re
 import socket
 import urllib.parse
 from collections.abc import Awaitable, Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 import aiohttp
@@ -147,7 +147,8 @@ class DigitalstromClient:
         # Send an authenticated request to the server
         # Previous login via request_app_token or set_app_token is required
         if (self.last_request is None) or (
-            self.last_request < datetime.now() - SESSION_TOKEN_TIMEOUT
+            self.last_request
+            < datetime.now() - timedelta(seconds=SESSION_TOKEN_TIMEOUT)
         ):
             self._session_token = await self.request_session_token()
         data = await self._request_raw(url, dict(token=self._session_token))

--- a/custom_components/digitalstrom/api/client.py
+++ b/custom_components/digitalstrom/api/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import binascii
+import inspect
 import json
 import re
 import socket
@@ -41,7 +42,7 @@ class DigitalstromClient:
         self._app_token: str | None = None
         self._session_token: str | None = None
         self._ws: aiohttp.ClientSession | None = None
-        self._event_callbacks: list[Callable[[dict], Awaitable[None]]] = []
+        self._event_callbacks: list[Callable[[dict], Awaitable[None] | None]] = []
         if type(ssl) is bool:
             self.ssl = None if ssl else False
         elif type(ssl) is str:
@@ -154,13 +155,19 @@ class DigitalstromClient:
         return data
 
     def register_event_callback(
-        self, callback: Callable[[dict], Awaitable[None]]
+        self, callback: Callable[[dict], Awaitable[None] | None]
     ) -> None:
         # Register an event callback
         self._event_callbacks.append(callback)
 
+    def set_event_callback(
+        self, callback: Callable[[dict], Awaitable[None] | None]
+    ) -> None:
+        # Register an event callback
+        self.register_event_callback(callback)
+
     def unregister_event_callback(
-        self, callback: Callable[[dict], Awaitable[None]]
+        self, callback: Callable[[dict], Awaitable[None] | None]
     ) -> None:
         # Unregister an event callback
         if callback in self._event_callbacks:
@@ -189,7 +196,9 @@ class DigitalstromClient:
                             event = json.loads(msg.data)
                             if event.get("name"):
                                 for callback in self._event_callbacks:
-                                    await callback(event)
+                                    result = callback(event)
+                                    if inspect.isawaitable(result):
+                                        await result
                         elif msg.type == aiohttp.WSMsgType.CLOSED:
                             break
                         elif msg.type == aiohttp.WSMsgType.ERROR:


### PR DESCRIPTION
## Summary
This PR adds support for digitalSTROM scene events in Home Assistant.

Whenever a scene is triggered (e.g. via physical switches), an event
`digitalstrom_scene` is fired on the Home Assistant event bus.

## Features
- Emits events for scene changes
- Includes scene, zone and group in event data
- Enables automations based on digitalSTROM inputs

## Documentation
- Added usage documentation (EN + DE) to README

## Technical details
- Uses digitalSTROM event API (`event/subscribe`, `event/get`)
- Emits events via `hass.bus.async_fire`

## Tested with
- Home Assistant OS (x86)
- digitalSTROM dSS
- Physical switches triggering scenes